### PR TITLE
Added Working Release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,18 @@
 name: 'publish'
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+    types:
+      - closed
 
 # This is the example from the readme.
 # On each push to the `release` branch it will create or update a GitHub release, build your app, and upload the artifacts to the release.
 
 jobs:
   publish-tauri:
+    if: ${{ github.event.pull_request.merged }} # Only run on merged PRs.
     permissions:
       contents: write
     strategy:
@@ -58,6 +61,6 @@ jobs:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: 'App v__VERSION__'
           releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
- Auto tags the release on every accepted pull request into main. Creates the binaries on all platforms. Confirmed working with macos :)